### PR TITLE
dryrun mode and logfile

### DIFF
--- a/CODING.md
+++ b/CODING.md
@@ -34,6 +34,11 @@ consistently within a project.
   This function returns 1 or an optional code: `err "some error
   occured" 5`
 
+- **Execute Commands**: Use the `docmd()` function for executing
+  external commands. This finction wraps the checks if the command
+  should be executed and redirects the comands output.
+  Example: instead of `rcctl start foo` do `docmd rcctl start foo`
+
 
 ## Style Guide
 

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,10 +1,15 @@
 #!/bin/ksh
 
+readonly TIMESTAMP="$(date "+%Y-%m-%d-%H-%M-%S")"
+
 # exit immediately if a command exits with a non-zero status
 set -e
 
 # set OpenBSD version supported without the dot
 readonly VER=63
+
+# set filename of logfile
+readonly LOG="./logfile-${TIMESTAMP}.txt"
 
 # handle errors
 err()
@@ -18,9 +23,11 @@ docmd()
 	if [[ -n ${DRYRUN} ]]; then
     echo "[dryrun]  $@"
   else
-    "$@" 2>&1
+    echo "$@" >> ${LOG}
+    # append STDOUT to logfile
+    # convert STDERR to STDOUT which is piped to tee
+    ("$@" >> ${LOG}) 2>&1 | tee -a ${LOG}
     (( $? != 0 )) && err "FAILED:  $@\n         Failed with Status: $?" 
-    exit 1
 	fi
 }
 

--- a/bin/deploy
+++ b/bin/deploy
@@ -21,7 +21,7 @@ err()
 docmd()
 {
   if [[ -n ${DRYRUN} ]]; then
-    echo "[dryrun]  $@"
+    echo "$@"
   else
     echo "$@" >> ${LOG}
     # append STDOUT to logfile
@@ -77,7 +77,7 @@ while getopts :dn opt; do
 done
 
 # running in dryrun mode?
-[[ -n ${DRYRUN} ]] && echo "Running in dryrun mode" 
+[[ -n ${DRYRUN} ]] && echo "Doing a dryrun - Not executing commands" 
 
 # only root can run this scipt if we are not in dryrun mode
 (($(id -u) != 0)) && ((DRYRUN != 1)) && err "You need root privileges" 

--- a/bin/deploy
+++ b/bin/deploy
@@ -12,6 +12,18 @@ err()
   echo "${1}" >&2 && return "${2:-1}"
 }
 
+# wrapper for executing commands
+docmd()
+{
+	if [[ -n ${DRYRUN} ]]; then
+    echo "[dryrun]  $@"
+  else
+    "$@" 2>&1
+    (( $? != 0 )) && err "FAILED:  $@\n         Failed with Status: $?" 
+    exit 1
+	fi
+}
+
 # install all libraries (opensmtpd, dovecot ...)
 install_all()
 {
@@ -23,7 +35,13 @@ install_all()
 
 usage()
 {
-  err "Usage: ${0##*/} [-d] [library]"
+  echo "Usage: ${0##*/} [-nd] [library]"
+  echo
+  echo "  -d :   Debugmode. Print commands and parameter assignments"
+  echo "         when they are executed."
+  echo 
+  echo "  -n :   Not executing commands just print out what will happen."
+  echo "         This mode is also known as dryrun."
 }
 
 # Backup configuration file to /etc/examples
@@ -32,28 +50,31 @@ backup()
   local _filename="${1##*/}" _examples=/etc/examples
   if [ -r "$1" ]; then
     if [ ! -r $_examples/"$_filename" ]; then
-      cp -p "$1" $_examples
+      docmd cp -p "$1" $_examples
     else
-      cp -p "$1" $_examples/"$_filename"-"$(date "+%Y-%m-%d-%H-%M-%S")"
+      docmd cp -p "$1" $_examples/"$_filename"-"$(date "+%Y-%m-%d-%H-%M-%S")"
     fi
   fi
 }
-
-# you need 'root' user for this script!
-(($(id -u) != 0)) && err "${0##*/}: need root privileges"
 
 # are you using the good release ?
 (($(uname -r | tr -d .) != VER)) && \
   err "${0##*/}: this release is not supported"
 
 # the syntax
-while getopts :d opt; do
+while getopts :dn opt; do
   case ${opt} in
-# Debug mode when -d is present
-  d) set -x && readonly DEBUG=1;;
-  *) usage;;
+    d) set -x && readonly DEBUG=1;;    # Debug mode when -d is present
+    n) readonly DRYRUN=1;;             # Not executing commands
+    *) usage;;
   esac
 done
+
+# running in dryrun mode?
+[[ -n ${DRYRUN} ]] && echo "Running in dryrun mode" 
+
+# only root can run this scipt if we are not in dryrun mode
+(($(id -u) != 0)) && ((DRYRUN != 1)) && err "You need root privileges" 
 
 # we remove an option
 shift $((OPTIND - 1))

--- a/bin/deploy
+++ b/bin/deploy
@@ -20,15 +20,14 @@ err()
 # wrapper for executing commands
 docmd()
 {
-	if [[ -n ${DRYRUN} ]]; then
+  if [[ -n ${DRYRUN} ]]; then
     echo "[dryrun]  $@"
   else
     echo "$@" >> ${LOG}
     # append STDOUT to logfile
     # convert STDERR to STDOUT which is piped to tee
     ("$@" >> ${LOG}) 2>&1 | tee -a ${LOG}
-    (( $? != 0 )) && err "FAILED:  $@\n         Failed with Status: $?" 
-	fi
+  fi
 }
 
 # install all libraries (opensmtpd, dovecot ...)

--- a/lib/02_opensmtpd
+++ b/lib/02_opensmtpd
@@ -28,11 +28,11 @@ EOF
 
   # create a single system user named vmail if not exists
   /usr/bin/getent passwd vmail > /dev/null || \
-    /usr/sbin/useradd -m -g =uid -L vmail -c "Virtual Mail" \
-    -d /var/vmail -s /sbin/nologin vmail
+    docmd /usr/sbin/useradd -m -g =uid -L vmail \
+    -c "Virtual Mail" -d /var/vmail -s /sbin/nologin vmail
 
  # install templates
- /usr/bin/install -m 644 ./conf/opensmtpd/smtpd.conf /etc/mail
+ docmd /usr/bin/install -m 644 ./conf/opensmtpd/smtpd.conf /etc/mail
 
  # start smtpd
  docmd /usr/sbin/rcctl start smtpd

--- a/lib/02_opensmtpd
+++ b/lib/02_opensmtpd
@@ -5,11 +5,11 @@ opensmtpd_lib()
 
   # add OpenSMTPD-extras
   if (! /usr/sbin/pkg_info | grep -q opensmtpd-extras); then
-    /usr/sbin/pkg_add opensmtpd-extras
+    docmd /usr/sbin/pkg_add opensmtpd-extras
   fi
 
   # stop smtpd
-  /usr/sbin/rcctl stop smtpd >/dev/null 2>&1
+  docmd /usr/sbin/rcctl stop smtpd
 
   # backup existing /etc/mail/smtpd.conf to /etc/examples
   backup /etc/mail/smtpd.conf
@@ -35,5 +35,5 @@ EOF
  /usr/bin/install -m 644 ./conf/opensmtpd/smtpd.conf /etc/mail
 
  # start smtpd
- /usr/sbin/rcctl start smtpd >/dev/null 2>&1
+ docmd /usr/sbin/rcctl start smtpd
 }


### PR DESCRIPTION
- dryrun  when excecuted with `deploy -n`. In dryrun commands are not executed. Just printed out what will be done. The dryrun can be started without root privileges because no filles are modifiesd in dryrun
- a logfile is written when running not in dryrun
